### PR TITLE
#8 - Implement type jailing for every public method calls

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -27,7 +27,6 @@ tools:
     php_mess_detector:
         enabled: true
         config:
-            ruleset: phpmd.xml.dist
             design_rules: { eval_expression: false }
         filter:
             paths: ["src/*"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - 7
   - hhvm
 
+before_script:
+  - composer update
+
 script:
   # note: not activating `--report-useless-tests` as we are currently having many tests with no assertions
   #- ./vendor/bin/phpunit --disallow-test-output --report-useless-tests --coverage-clover ./clover.xml

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ operate, specifically [go-aop-php](https://github.com/lisachenko/go-aop-php).
 Go AOP PHP has some limitations when it comes to intercepting access to
 private class members, so please be aware that it has limited scope (for now).
 
+This package only works against autoloaded classes: classes that aren't handled by
+an autoloader cannot be rectified by StrictPhp.
+
 ## License
 
 This package is released under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # StrictPhp
 
 [![Build Status](https://travis-ci.org/Roave/StrictPhp.svg)](https://travis-ci.org/Roave/StrictPhp)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Roave/StrictPhp/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Roave/StrictPhp/?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/Roave/StrictPhp/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/Roave/StrictPhp/?branch=master)
 
 StrictPhp is a development tool aimed at bringing stricter runtime assertions
 into PHP applications and libraries.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StrictPhp
 
+[![Build Status](https://travis-ci.org/Roave/StrictPhp.svg)](https://travis-ci.org/Roave/StrictPhp)
+
 StrictPhp is a development tool aimed at bringing stricter runtime assertions
 into PHP applications and libraries.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $object->immutableProperty = 'another value'; // crash
 Please note that this kind of feature currently only works with public and 
 protected properties.
 
-## Public constructor property initialization checks
+#### Public constructor property initialization checks
 
 This feature of StrictPhp allows checking whether a public constructor of
 a class fully initialized an object.
@@ -142,6 +142,50 @@ class Example
     }
 }
 ```
+
+#### Parameter interface jailing
+
+This feature of StrictPhp "jails" (restricts) calls to non-interfaced methods
+whenever an interface is used as a type-hint.
+
+Following example will work, but will crash if StrictPhp is enabled:
+
+```php
+interface HornInterface
+{
+    public function honk();
+}
+
+class TheUsualHorn implements HornInterface
+{
+    public function honk() { var_dump('honk'); }
+    public function sadTrombone() { var_dump('pooapooapooapoaaaa'); }
+}
+
+class Car
+{
+    public function honk(HornInterface $horn, $sad = false)
+    {
+        if ($sad) {
+            // method not covered by interface: crash
+            $horn->sadTrombone();
+            
+            return;
+        }
+        
+        // interface respected
+        $horn->honk();
+    }
+}
+
+$car  = new Car();
+$horn = new TheUsualHorn();
+
+$car->honk($horn, false); // works
+$car->honk($horn, true); // crashes
+```
+
+This prevents consumers of your APIs to design their code against non-API methods.
 
 ## Current limitations
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ class Car
         $horn->honk();
     }
 }
+```
 
+```php
 $car  = new Car();
 $horn = new TheUsualHorn();
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php":                               "~5.6|~7.0",
         "lisachenko/go-aop-php":             "0.6.*",
         "phpdocumentor/reflection-docblock": "~2.0",
-        "phpdocumentor/type-resolver":       "dev-master"
+        "phpdocumentor/type-resolver":       "dev-master",
+        "internations/type-jail":            "0.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7"

--- a/src/StrictPhp/AccessChecker/ParameterInterfaceJailer.php
+++ b/src/StrictPhp/AccessChecker/ParameterInterfaceJailer.php
@@ -11,10 +11,6 @@ use InterNations\Component\TypeJail\Factory\JailFactoryInterface;
 use ReflectionMethod;
 use ReflectionParameter;
 
-/**
- * Note: this class extends {@see \Go\Aop\Framework\AbstractMethodInvocation}
- * just to have access to its protected members without too many scope hacks
- */
 final class ParameterInterfaceJailer
 {
     /**

--- a/src/StrictPhp/AccessChecker/ParameterInterfaceJailer.php
+++ b/src/StrictPhp/AccessChecker/ParameterInterfaceJailer.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace StrictPhp\AccessChecker;
+
+use Go\Aop\Framework\AbstractMethodInvocation;
+use Go\Lang\Annotation as Go;
+use InterNations\Component\TypeJail\Exception\ExceptionInterface;
+use InterNations\Component\TypeJail\Exception\HierarchyException;
+use InterNations\Component\TypeJail\Factory\JailFactoryInterface;
+use ReflectionMethod;
+use ReflectionParameter;
+
+/**
+ * Note: this class extends {@see \Go\Aop\Framework\AbstractMethodInvocation}
+ * just to have access to its protected members without too many scope hacks
+ */
+final class ParameterInterfaceJailer extends AbstractMethodInvocation
+{
+    /**
+     * @var JailFactoryInterface
+     */
+    private $jailFactory;
+
+    /**
+     * @param JailFactoryInterface $jailFactory
+     */
+    public function __construct(JailFactoryInterface $jailFactory)
+    {
+        $this->jailFactory = $jailFactory;
+
+        //parent::__construct(__CLASS__, __METHOD__, []);
+    }
+
+    /**
+     * Replaces the parameters within the given $methodInvocation with type-safe interface jails, whenever applicable
+     *
+     * @param AbstractMethodInvocation $methodInvocation
+     *
+     * @return void
+     *
+     * @throws ExceptionInterface
+     * @throws HierarchyException
+     */
+    public function jail(AbstractMethodInvocation $methodInvocation)
+    {
+        $method = $methodInvocation->getMethod();
+
+        foreach ($methodInvocation->arguments as $parameterIndex => & $argument) {
+            if (null === $argument) {
+                continue;
+            }
+
+            if (! $interface = $this->getParameterInterfaceType($method, $parameterIndex)) {
+                continue;
+            }
+
+            $argument = $this->jailFactory->createInstanceJail($argument, $interface);
+        }
+    }
+
+    /**
+     * @param ReflectionMethod $reflectionMethod
+     * @param int              $index
+     *
+     * @return ReflectionParameter
+     */
+    private function getParameterInterfaceType(ReflectionMethod $reflectionMethod, $index)
+    {
+        $parameters = $reflectionMethod->getParameters();
+
+        if (isset($parameters[$index])) {
+            return $this->getInterface($parameters[$index]);
+        }
+
+        /* @var $lastParameter \ReflectionParameter|null */
+        $lastParameter = end($parameters);
+
+        return $lastParameter && $lastParameter->isVariadic()
+            ? $this->getInterface($lastParameter)
+            : null;
+    }
+
+    /**
+     * @param ReflectionParameter $parameter
+     *
+     * @return string|null
+     */
+    private function getInterface(ReflectionParameter $parameter)
+    {
+        return ($class = $parameter->getClass())
+            && $class->isInterface()
+            ? $class->getName()
+            : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Note: method implemented just to please the abstract definition, but not supposed to be called directly
+     *
+     * @throws \BadMethodCallException
+     */
+    public function proceed()
+    {
+        throw new \BadMethodCallException('Unsupported - this class is a scope hack, not supposed to be used directly');
+    }
+}

--- a/src/StrictPhp/Aspect/PrePublicMethodAspect.php
+++ b/src/StrictPhp/Aspect/PrePublicMethodAspect.php
@@ -29,7 +29,7 @@ final class PrePublicMethodAspect implements Aspect
      *
      * @return mixed
      */
-    public function postConstruct(AbstractMethodInvocation $methodInvocation)
+    public function prePublicMethod(AbstractMethodInvocation $methodInvocation)
     {
         // following line is executed in the scope of AbstractMethodInvocation
         $arguments = & $methodInvocation->arguments; // UNSAFE

--- a/src/StrictPhp/Aspect/PrePublicMethodAspect.php
+++ b/src/StrictPhp/Aspect/PrePublicMethodAspect.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace StrictPhp\Aspect;
+
+use Go\Aop\Aspect;
+use Go\Lang\Annotation as Go;
+use Go\Aop\Framework\AbstractMethodInvocation;
+use InterNations\Component\TypeJail\Factory\JailFactory;
+
+final class PrePublicMethodAspect implements Aspect
+{
+    /**
+     * @var callable[]
+     */
+    private $stateCheckers;
+
+    /**
+     * @param callable ...$stateCheckers
+     */
+    public function __construct(callable ...$stateCheckers)
+    {
+        $this->stateCheckers = $stateCheckers;
+    }
+
+    /**
+     * @Go\Before("execution(public **->*(*))", scope=AbstractMethodInvocation::class)
+     *
+     * @param AbstractMethodInvocation $methodInvocation
+     *
+     * @return mixed
+     */
+    public function postConstruct(AbstractMethodInvocation $methodInvocation)
+    {
+        // following line is executed in the scope of AbstractMethodInvocation
+        $arguments = & $methodInvocation->arguments; // UNSAFE
+
+        foreach ($methodInvocation->getMethod()->getParameters() as $parameterIndex => $parameter) {
+            if (! $class = $parameter->getClass()) {
+                continue;
+            }
+
+            if (null === $arguments[$parameterIndex] && $parameter->isOptional()) {
+                continue;
+            }
+
+            if (! $class->isInterface()) {
+                continue;
+            }
+
+            $arguments[$parameterIndex] = (new JailFactory())
+                ->createInstanceJail($arguments[$parameterIndex], $class->getName());
+        }
+
+        return $methodInvocation->proceed();
+    }
+}

--- a/src/StrictPhp/StrictPhpKernel.php
+++ b/src/StrictPhp/StrictPhpKernel.php
@@ -8,6 +8,7 @@ use StrictPhp\AccessChecker\ObjectStateChecker;
 use StrictPhp\AccessChecker\PropertyWriteImmutabilityChecker;
 use StrictPhp\AccessChecker\PropertyWriteTypeChecker;
 use StrictPhp\Aspect\PostConstructAspect;
+use StrictPhp\Aspect\PrePublicMethodAspect;
 use StrictPhp\Aspect\PropertyWriteAspect;
 use StrictPhp\TypeChecker\ApplyTypeChecks;
 use StrictPhp\TypeChecker\TypeChecker\CallableTypeChecker;
@@ -47,5 +48,6 @@ class StrictPhpKernel extends AspectKernel
             new ApplyTypeChecks(...$typeCheckers),
             new PropertyTypeFinder()
         )));
+        $container->registerAspect(new PrePublicMethodAspect());
     }
 }

--- a/src/StrictPhp/StrictPhpKernel.php
+++ b/src/StrictPhp/StrictPhpKernel.php
@@ -4,7 +4,9 @@ namespace StrictPhp;
 
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
+use InterNations\Component\TypeJail\Factory\JailFactory;
 use StrictPhp\AccessChecker\ObjectStateChecker;
+use StrictPhp\AccessChecker\ParameterInterfaceJailer;
 use StrictPhp\AccessChecker\PropertyWriteImmutabilityChecker;
 use StrictPhp\AccessChecker\PropertyWriteTypeChecker;
 use StrictPhp\Aspect\PostConstructAspect;
@@ -48,6 +50,8 @@ class StrictPhpKernel extends AspectKernel
             new ApplyTypeChecks(...$typeCheckers),
             new PropertyTypeFinder()
         )));
-        $container->registerAspect(new PrePublicMethodAspect());
+        $container->registerAspect(new PrePublicMethodAspect(
+            [new ParameterInterfaceJailer(new JailFactory()), 'jail']
+        ));
     }
 }

--- a/src/StrictPhp/StrictPhpKernel.php
+++ b/src/StrictPhp/StrictPhpKernel.php
@@ -50,8 +50,6 @@ class StrictPhpKernel extends AspectKernel
             new ApplyTypeChecks(...$typeCheckers),
             new PropertyTypeFinder()
         )));
-        $container->registerAspect(new PrePublicMethodAspect(
-            [new ParameterInterfaceJailer(new JailFactory()), 'jail']
-        ));
+        $container->registerAspect(new PrePublicMethodAspect(new ParameterInterfaceJailer(new JailFactory())));
     }
 }

--- a/tests/StrictPhpTest/AccessChecker/ParameterInterfaceJailerTest.php
+++ b/tests/StrictPhpTest/AccessChecker/ParameterInterfaceJailerTest.php
@@ -40,13 +40,6 @@ class ParameterInterfaceJailerTest extends \PHPUnit_Framework_TestCase
         $this->jailer      = new ParameterInterfaceJailer($this->jailFactory);
     }
 
-    public function testProceedIsDisabled()
-    {
-        $this->setExpectedException(\BadMethodCallException::class);
-
-        $this->jailer->proceed();
-    }
-
     /**
      * @dataProvider jailExpectationParameters
      *
@@ -76,7 +69,9 @@ class ParameterInterfaceJailerTest extends \PHPUnit_Framework_TestCase
                 return $expectedJails[array_search($value, $parameters, true)];
             }));
 
-        $this->jailer->jail($methodInvocation);
+        $jailer = $this->jailer;
+
+        $jailer($methodInvocation);
 
         $jailedParameters = $parameters;
 

--- a/tests/StrictPhpTest/AccessChecker/ParameterInterfaceJailerTest.php
+++ b/tests/StrictPhpTest/AccessChecker/ParameterInterfaceJailerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace StrictPhpTest\Aspect;
+
+use Go\Aop\Framework\AbstractMethodInvocation;
+use InterNations\Component\TypeJail\Factory\JailFactoryInterface;
+use ReflectionMethod;
+use ReflectionProperty;
+use StrictPhp\AccessChecker\ParameterInterfaceJailer;
+use StrictPhpTestAsset\ClassWithVariadicInterfaceParameters;
+
+/**
+ * Tests for {@see \StrictPhp\AccessChecker\ParameterInterfaceJailer}
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @license MIT
+ *
+ * @group Coverage
+ *
+ * @covers \StrictPhp\AccessChecker\ParameterInterfaceJailer
+ */
+class ParameterInterfaceJailerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var JailFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $jailFactory;
+
+    /**
+     * @var ParameterInterfaceJailer
+     */
+    private $jailer;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->jailFactory = $this->getMock(JailFactoryInterface::class);
+        $this->jailer      = new ParameterInterfaceJailer($this->jailFactory);
+    }
+
+    public function testProceedIsDisabled()
+    {
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $this->jailer->proceed();
+    }
+
+    /**
+     * @dataProvider jailExpectationParameters
+     *
+     * @param string $class
+     * @param string $method
+     * @param array  $parameters
+     * @param array  $expectedJails
+     */
+    public function testJailingWithParameters($class, $method, array $parameters, array $expectedJails)
+    {
+        /* @var $methodInvocation AbstractMethodInvocation|\PHPUnit_Framework_MockObject_MockObject */
+        $methodInvocation = $this->getMockForAbstractClass(AbstractMethodInvocation::class, [], '', false);
+        $invocationArgs   = new ReflectionProperty(AbstractMethodInvocation::class, 'arguments');
+        $invocationMethod = new ReflectionProperty(AbstractMethodInvocation::class, 'reflectionMethod');
+
+        $invocationArgs->setAccessible(true);
+        $invocationMethod->setAccessible(true);
+        $invocationArgs->setValue($methodInvocation, $parameters);
+        $invocationMethod->setValue($methodInvocation, new ReflectionMethod($class, $method));
+
+        $this
+            ->jailFactory
+            ->expects($this->exactly(count($expectedJails)))
+            ->method('createInstanceJail')
+            ->with($this->logicalOr(...array_intersect_key($parameters, $expectedJails)))
+            ->will($this->returnCallback(function ($value) use ($expectedJails, $parameters) {
+                return $expectedJails[array_search($value, $parameters, true)];
+            }));
+
+        $this->jailer->jail($methodInvocation);
+
+        $jailedParameters = $parameters;
+
+        foreach ($expectedJails as $key => $jailed) {
+            $jailedParameters[$key] = $jailed;
+        }
+
+        $this->assertSame($jailedParameters, $invocationArgs->getValue($methodInvocation));
+    }
+
+    /**
+     * Data provider
+     *
+     * @return string[][]|mixed[][]
+     */
+    public function jailExpectationParameters()
+    {
+        $someObject1     = new \stdClass();
+        $someObject2     = new \stdClass();
+        $someObject3     = new \stdClass();
+        $someObject4     = new \stdClass();
+        $someObjectJail1 = new \stdClass();
+        $someObjectJail2 = new \stdClass();
+        $someObjectJail3 = new \stdClass();
+        $someObjectJail4 = new \stdClass();
+
+        return [
+            'no parameters' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithNoParameters',
+                [],
+                [],
+            ],
+            'more parameters than which are defined in the method' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithNoParameters',
+                ['foo'],
+                [],
+            ],
+            'more (compatible) parameter than which are defined in the method' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithNoParameters',
+                [$someObject1],
+                [],
+            ],
+            'call to a method with an interfaced hint' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithSingleParameter',
+                [$someObject1],
+                [$someObjectJail1],
+            ],
+            'call to a method with an interfaced hint (and additional undefined parameter)' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithSingleParameter',
+                [$someObject1, 'foo'],
+                [$someObjectJail1],
+            ],
+            'call to a method with variadic parameters (0 parameters given)' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithVariadicSingleParameter',
+                [],
+                [],
+            ],
+            'call to a method with variadic parameters (many parameters given)' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithVariadicSingleParameter',
+                [$someObject1, $someObject2, $someObject3, $someObject4],
+                [$someObjectJail1, $someObjectJail2, $someObjectJail3, $someObjectJail4],
+            ],
+            'call to a method with an interfaced parameter and a variadic interfaced parameter (1 parameter)' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithParameterAndVariadicSingleParameter',
+                [$someObject1],
+                [$someObjectJail1],
+            ],
+            'call to a method with an interfaced parameter and a variadic interfaced parameter (2 parameters)' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithParameterAndVariadicSingleParameter',
+                [$someObject1, $someObject2],
+                [$someObjectJail1, $someObjectJail2],
+            ],
+            'call to a method with an interfaced parameter and a variadic interfaced parameter (3 parameters)' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithParameterAndVariadicSingleParameter',
+                [$someObject1, $someObject2, $someObject3],
+                [$someObjectJail1, $someObjectJail2, $someObjectJail3],
+            ],
+            'call to a method with an interfaced and a non interfaced parameter' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithInterfacedAndNonInterfacedParameters',
+                [$someObject1, $someObject2],
+                [$someObjectJail1],
+            ],
+            'call to a method with an non interfaced and an interfaced parameter' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithNonInterfacedAndInterfacedParameters',
+                [$someObject1, $someObject2],
+                [1 => $someObjectJail2],
+            ],
+            'call to a method with an concrete type hint and an interfaced parameter' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithConcreteTypeHintAndInterfaceHint',
+                [$someObject1, $someObject2],
+                [1 => $someObjectJail2],
+            ],
+            'call to a method with a "null" default interface hint' => [
+                ClassWithVariadicInterfaceParameters::class,
+                'methodWithInterfacedHintAndDefaultNull',
+                [null],
+                [],
+            ],
+        ];
+    }
+}

--- a/tests/StrictPhpTest/Aspect/PrePublicMethodAspectTest.php
+++ b/tests/StrictPhpTest/Aspect/PrePublicMethodAspectTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace StrictPhpTest\Aspect;
+
+use Go\Aop\Framework\AbstractMethodInvocation;
+use Go\Aop\Intercept\MethodInvocation;
+use StrictPhp\Aspect\PrePublicMethodAspect;
+
+/**
+ * Tests for {@see \StrictPhp\Aspect\PrePublicMethodAspect}
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @license MIT
+ *
+ * @group Coverage
+ *
+ * @covers \StrictPhp\Aspect\PrePublicMethodAspect
+ */
+class PrePublicMethodAspectTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MethodInvocation|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $methodInvocation;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject[]|callable[]
+     */
+    private $callables = [];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->methodInvocation = $this->getMock(MethodInvocation::class);
+        $this->callables        = [
+            $this->getMock('stdClass', ['__invoke']),
+            $this->getMock('stdClass', ['__invoke']),
+        ];
+    }
+
+    public function testWillExecuteAllInterceptorsOnCall()
+    {
+        /* @var $methodInvocation AbstractMethodInvocation|\PHPUnit_Framework_MockObject_MockObject */
+        $methodInvocation = $this->getMockForAbstractClass(AbstractMethodInvocation::class, [], '', false);
+
+        /* @var $callables callable[]|\PHPUnit_Framework_MockObject_MockObject[] */
+        $callables = [
+            $this->getMock('stdClass', ['__invoke']),
+            $this->getMock('stdClass', ['__invoke']),
+            $this->getMock('stdClass', ['__invoke']),
+        ];
+
+        foreach ($callables as $callable) {
+            $callable->expects($this->once())->method('__invoke')->with($methodInvocation);
+        }
+
+        $aspect = new PrePublicMethodAspect(...$callables);
+
+        $methodInvocation->expects($this->once())->method('proceed')->will($this->returnValue('result'));
+
+        $this->assertSame('result', $aspect->prePublicMethod($methodInvocation));
+    }
+}

--- a/tests/StrictPhpTestAsset/ClassThatDependsOnHello.php
+++ b/tests/StrictPhpTestAsset/ClassThatDependsOnHello.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace StrictPhpTestAsset;
+
+class ClassThatDependsOnHello
+{
+    /**
+     * @param HelloInterface $helloSayer
+     * @param                $name
+     *
+     * @return string
+     */
+    public function sayHello(HelloInterface $helloSayer, $name)
+    {
+        return $helloSayer->hello($name);
+    }
+
+    /**
+     * @param HelloInterface $helloSayer
+     *
+     * @return string
+     */
+    public function doSomethingElseWithHello(HelloInterface $helloSayer)
+    {
+        /* @var $helloSayer ClassWithHelloImplementationAndAdditionalMethod */
+        return $helloSayer->otherMethod();
+    }
+}

--- a/tests/StrictPhpTestAsset/ClassWithHelloImplementationAndAdditionalMethod.php
+++ b/tests/StrictPhpTestAsset/ClassWithHelloImplementationAndAdditionalMethod.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace StrictPhpTestAsset;
+
+class ClassWithHelloImplementationAndAdditionalMethod implements HelloInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function hello($name)
+    {
+        return 'hello ' . $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function otherMethod()
+    {
+        return 'Other method';
+    }
+}

--- a/tests/StrictPhpTestAsset/ClassWithVariadicInterfaceParameters.php
+++ b/tests/StrictPhpTestAsset/ClassWithVariadicInterfaceParameters.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace StrictPhpTestAsset;
+
+class ClassWithVariadicInterfaceParameters
+{
+    /**
+     * @return void
+     */
+    public function methodWithNoParameters()
+    {
+    }
+
+    /**
+     * @param HelloInterface $hello
+     *
+     * @return void
+     */
+    public function methodWithSingleParameter(HelloInterface $hello)
+    {
+    }
+
+    /**
+     * @param HelloInterface ...$hello
+     *
+     * @return void
+     */
+    public function methodWithVariadicSingleParameter(HelloInterface ...$hello)
+    {
+    }
+
+    /**
+     * @param HelloInterface $hello1
+     * @param HelloInterface ...$hello2
+     *
+     * @return void
+     */
+    public function methodWithParameterAndVariadicSingleParameter(HelloInterface $hello1, HelloInterface ...$hello2)
+    {
+    }
+
+    /**
+     * @param HelloInterface $hello1
+     * @param mixed          $hello2
+     *
+     * @return void
+     */
+    public function methodWithInterfacedAndNonInterfacedParameters(HelloInterface $hello1, $hello2)
+    {
+    }
+
+    /**
+     * @param mixed          $hello1
+     * @param HelloInterface $hello2
+     *
+     * @return void
+     */
+    public function methodWithNonInterfacedAndInterfacedParameters($hello1, HelloInterface $hello2)
+    {
+    }
+
+    /**
+     * @param ClassWithHelloImplementationAndAdditionalMethod $hello1
+     * @param HelloInterface                                  $hello2
+     *
+     * @return void
+     */
+    public function methodWithConcreteTypeHintAndInterfaceHint(
+        ClassWithHelloImplementationAndAdditionalMethod $hello1,
+        HelloInterface $hello2
+    ) {
+    }
+
+    /**
+     * @param HelloInterface|null $hello1
+     *
+     * @return void
+     */
+    public function methodWithInterfacedHintAndDefaultNull(HelloInterface $hello1 = null)
+    {
+    }
+}

--- a/tests/StrictPhpTestAsset/HelloInterface.php
+++ b/tests/StrictPhpTestAsset/HelloInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace StrictPhpTestAsset;
+
+interface HelloInterface
+{
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function hello($name);
+}

--- a/tests/functional/call-to-non-interfaced-method-violation.phpt
+++ b/tests/functional/call-to-non-interfaced-method-violation.phpt
@@ -18,4 +18,4 @@ echo 'Never reached'
 
 ?>
 --EXPECTF--
-%ACatchable fatal error: call to undefined method ...
+%AFatal error: Uncaught exception 'InterNations\Component\TypeJail\Exception\JailException' with message 'Jailed method "%a::otherMethod()" invoked on proxy restricted to "StrictPhpTestAsset\HelloInterface". Check file "%a" to find out which method calls are allowed%a

--- a/tests/functional/call-to-non-interfaced-method-violation.phpt
+++ b/tests/functional/call-to-non-interfaced-method-violation.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Verifies that calling a non-interfaced method in a context that is only aware of the interface causes a fatal error
+--FILE--
+<?php
+
+require_once __DIR__ . '/init.php';
+
+$helloSayer = new \StrictPhpTestAsset\ClassWithHelloImplementationAndAdditionalMethod();
+$helloUser  = new \StrictPhpTestAsset\ClassThatDependsOnHello();
+
+$helloUser->sayHello($helloSayer, 'Marco');
+
+echo "\nOK";
+
+$helloUser->doSomethingElseWithHello($helloSayer);
+
+echo 'Never reached'
+
+?>
+--EXPECTF--
+%ACatchable fatal error: call to undefined method ...


### PR DESCRIPTION
Provides implementation for #8

What happens:

 - method is called
 - parameters are iterated
 - parameters that are type-hinted with an interface are replaced with a type-jail
 - type-jail ensures that any call on the object MUST be within the boundaries of the interface