### PR TITLE
Fix ObjectTypeChecker::validate()

### DIFF
--- a/src/StrictPhp/TypeChecker/TypeChecker/ObjectTypeChecker.php
+++ b/src/StrictPhp/TypeChecker/TypeChecker/ObjectTypeChecker.php
@@ -55,7 +55,7 @@ final class ObjectTypeChecker implements TypeCheckerInterface
             ));
         }
 
-        $fqcnString = $fqcn->getName();
+        $fqcnString = (string) $fqcn;
 
         return $value instanceof $fqcnString;
     }

--- a/tests/StrictPhpTest/TypeChecker/TypeChecker/ObjectTypeCheckerTest.php
+++ b/tests/StrictPhpTest/TypeChecker/TypeChecker/ObjectTypeCheckerTest.php
@@ -134,7 +134,7 @@ class ObjectTypeCheckerTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [new StdClass,    new Object_(new Fqsen('\\' . StdClass::class)), true],
-            [new DateTime,    new Object_(new Fqsen('\\' . DateTime::class)), true],
+            [new DateTime,    new Object_(new Fqsen('\\NotActually\\DateTime')), false],
             [123,             new Object_(new Fqsen('\\' . StdClass::class)), false],
             [0x12,            new Object_(new Fqsen('\\' . StdClass::class)), false],
             ['Marco Pivetta', new Object_(new Fqsen('\\' . StdClass::class)), false],


### PR DESCRIPTION
Fqsen->getName() returns the shortname. Cast to string to get the FQCN.

(Sorry for the very lazy test)