### PR TITLE
Switch to the goaop/framework package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "require": {
         "php":                               "~5.6|~7.0",
-        "lisachenko/go-aop-php":             "~1.0.0@ALPHA",
+        "goaop/framework":                   "~1.0.0@ALPHA",
         "phpdocumentor/reflection-docblock": "~2.0",
         "phpdocumentor/type-resolver":       "dev-master",
         "internations/type-jail":            "0.4.*"


### PR DESCRIPTION
Old name should be deprecated since 1.0.0 version.