### PR TITLE
set phpdocumentor/type-resolver to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php":                               "~5.6|~7.0",
         "goaop/framework":                   "~1.0.0@ALPHA",
         "phpdocumentor/reflection-docblock": "~2.0",
-        "phpdocumentor/type-resolver":       "dev-master",
+        "phpdocumentor/type-resolver":       "^0.1.5",
         "internations/type-jail":            "0.4.*"
     },
     "require-dev": {


### PR DESCRIPTION
We tagged the latest version in master of phpdocumentor/type-resolver. So I thought you would prefer a tag instead of a dev-master version.